### PR TITLE
(feature) improve results filter

### DIFF
--- a/odinochka.html
+++ b/odinochka.html
@@ -55,8 +55,7 @@
     input[name=importfile][value]:not([value=""]) ~ button[name=import] {display:block}
 
     div#groups {
-        display: flex;
-        flex-direction: column;
+        min-height: calc(100vh - 164px);
     }
 
     </style>
@@ -69,6 +68,8 @@
           min-height: 2em;
           padding-top: .5em;
           padding-bottom: .5em;
+          border-top: 1px solid black;
+          margin-bottom: 0;
       }
 
       .lbl-toggle ~ p {display: inline;}
@@ -92,7 +93,6 @@
   </head>
   <body>
 
-      
     <header>
         <h1>Odinochka</h1>
         <h2 id=size></h2>

--- a/odinochka.js
+++ b/odinochka.js
@@ -31,7 +31,7 @@ function debounce(func, wait, immediate) {
     };
 }
 
-function cssfilter(e) {
+function filterResults(e) {
     // render entire list from indexDB if input is empty
     var query = e.target.value
     if (query === '') {
@@ -333,7 +333,7 @@ function initOptions() {
     }
 
 
-    document.getElementsByName("filter")[0].addEventListener('input', debounce(cssfilter, 200))
+    document.getElementsByName("filter")[0].addEventListener('input', debounce(filterResults, 200))
 
     for (e of document.getElementsByName("favicon")) {
         e.onchange = function(e) {document.getElementById('faviconstyle').media = this.value == 'hide' ? 'not all' : 'all'}

--- a/odinochka.js
+++ b/odinochka.js
@@ -48,7 +48,7 @@ function filterResults(e) {
         allRecords.onsuccess = function() {
             const filteredAppData = allRecords.result.filter(function(cursor) {
                 return cursor.tabs.some(function(tab) {
-                    if (tab.title.match(query) || tab.url.match(query)) {
+                    if (tab.title.toLowerCase().match(query) || tab.url.toLowerCase().match(query)) {
                         return true
                     }
                     return false

--- a/odinochka.js
+++ b/odinochka.js
@@ -33,7 +33,7 @@ function debounce(func, wait, immediate) {
 
 function filterResults(e) {
     // render entire list from indexDB if input is empty
-    var query = e.target.value
+    const query = e.target.value
     if (query === '') {
         render()
         return
@@ -46,15 +46,13 @@ function filterResults(e) {
 
         let allRecords = store.getAll()
         allRecords.onsuccess = function() {
-            var filteredAppData = allRecords.result.filter(function(cursor) {
-                if (!cursor) return false
-                const result = cursor.tabs.some(function(tab) {
+            const filteredAppData = allRecords.result.filter(function(cursor) {
+                return cursor.tabs.some(function(tab) {
                     if (tab.title.match(query) || tab.url.match(query)) {
                         return true
                     }
                     return false
                 })
-                return result
             })
             render(filteredAppData)
         }

--- a/odinochka.js
+++ b/odinochka.js
@@ -46,7 +46,7 @@ function filterResults(e) {
 
         let allRecords = store.getAll()
         allRecords.onsuccess = function() {
-            const filteredAppData = allRecords.result.filter(function(cursor) {
+            const filteredResults = allRecords.result.filter(function(cursor) {
                 return cursor.tabs.some(function(tab) {
                     if (tab.title.toLowerCase().match(query) || tab.url.toLowerCase().match(query)) {
                         return true
@@ -54,7 +54,7 @@ function filterResults(e) {
                     return false
                 })
             })
-            render(filteredAppData)
+            render(filteredResults)
         }
     };
 }
@@ -414,15 +414,15 @@ function renderGroup(data, ddiv=null) {
     return ddiv;
 }
 
-// param:appData type: array
-function render(filteredAppData) {
+// param: filteredResults type: array
+function render(filteredResults) {
     // Building tab list
     let groupdiv = document.getElementById("groups");
     groupdiv.innerHTML = '';
 
-    if (filteredAppData && filteredAppData.length) {
-        filteredAppData.forEach(function(cursor) {
-            groupdiv.appendChild(renderGroup(cursor));
+    if (filteredResults && filteredResults.length) {
+        filteredResults.forEach(function(result) {
+            groupdiv.appendChild(renderGroup(result));
         })
     } else {
         window.indexedDB.open("odinochka", 5).onsuccess = function(event){

--- a/odinochka.js
+++ b/odinochka.js
@@ -46,14 +46,22 @@ function filterResults(e) {
 
         let allRecords = store.getAll()
         allRecords.onsuccess = function() {
-            const filteredResults = allRecords.result.filter(function(cursor) {
-                return cursor.tabs.some(function(tab) {
-                    if (tab.title.toLowerCase().match(query) || tab.url.toLowerCase().match(query)) {
-                        return true
+            const filteredResults = allRecords.result
+                .map(function(cursor) {
+                    const filteredTabs = cursor.tabs
+                        .map(function(tab) {
+                            if (tab.title.toLowerCase().match(query)
+                                || tab.url.toLowerCase().match(query)) {
+                                return tab
+                            }
+                        })
+                        .filter(function(tab) { return tab !== undefined})
+                    if (filteredTabs.length) {
+                        cursor.tabs = filteredTabs
+                        return cursor
                     }
-                    return false
                 })
-            })
+                .filter(function(cursor) { return cursor !== undefined })
             render(filteredResults)
         }
     };


### PR DESCRIPTION
@nfultz not sure if this will be performant enough for you or if you've already tried this before. lemme know and i can get more creative.

Also my text editor cleaned up the code style a bit (removing whitespace and improving indentation)

## Current functionality:
- filter box will filter based on either the title or the url of the entry.  Groups without any children that match the query will be hidden
- uses `debounce` to cut down unnecessary execution of `filterResults` on the input's 'input' event to cut down on costly results filtering logic  and DOM manipulation. ( current complexity analysis of `filterResults` is O(n*m) )