### PR TITLE
Nfultz/multirule css

### DIFF
--- a/odinochka.js
+++ b/odinochka.js
@@ -64,13 +64,14 @@ function cssfilter(x) {
     }
     else {
         keepselector = `a.tab[href*="${newfiltertxt}"]`;
-        selector = `a.tab[href*=${prefix}]:not([href*="${newfiltertxt}"])`;
+        selector = `a.tab[href*="${prefix}"]:not([href*="${newfiltertxt}"])`;
     }
 
-    var hideGroups = new Set(Array.from(document.querySelectorAll(selector)).map(x => x.parentNode.id));
-    var keepGroups = new Set(Array.from(document.querySelectorAll(keepselector)).map(x => x.parentNode.id));
+    var hideGroups = new Set();
+    document.querySelectorAll(".group").forEach(
+        x => window.getComputedStyle(x).display == "block" &&
+             ! x.querySelector(keepselector) ? hideGroups.add(x.id) : null)
 
-    var hideGroups = Array.from(hideGroups).filter(x => !keepGroups.has(x));
     for(var hide of hideGroups) {
         selector = selector + `, #\\3${hide.substring(0,1)} ${hide.substring(1,)}`
     }

--- a/odinochka.js
+++ b/odinochka.js
@@ -15,6 +15,22 @@ function newTabs(data) {
     data.tabs.forEach(o => chrome.tabs.create({url: o.url, pinned: o.pinned}))
 }
 
+function debounce(func, wait, immediate) {
+    let timeout;
+    return function(e) {
+        const context = e,
+                args = arguments;
+        const later = () => {
+                        timeout = null;
+                        if (!immediate) func.apply(context, args);
+                    };
+        const callNow = immediate && !timeout;
+        clearTimeout(timeout);
+        timeout = setTimeout(later, wait);
+        if (callNow) func.apply(context, args);
+    };
+}
+
 function cssfilter(x) {
     let node = document.getElementById("cssfilterstyle");
     if(x.target.value != "") {
@@ -298,7 +314,7 @@ function initOptions() {
     }
 
 
-    document.getElementsByName("filter")[0].oninput = cssfilter;
+    document.getElementsByName("filter")[0].oninput = debounce(cssfilter, 50);
 
     for (e of document.getElementsByName("favicon")) {
         e.onchange = function(e) {document.getElementById('faviconstyle').media = this.value == 'hide' ? 'not all' : 'all'}


### PR DESCRIPTION
Alternate for #1 performance issues

Instead of resetting style on each character, generate increasingly more specific css rules and concatenate them to the style sheet.

Filtering 3k tabs for stackoverflow using 50ms debounce => initial filter takes 250ms, subsequent get faster because less is changing at each pass. This looks very usable, but is an i7 workstation.

![image](https://user-images.githubusercontent.com/418638/77801870-efaf2800-7036-11ea-82dd-823c854235ae.png)

Will try on the rockchip.

There's some potential bugs when filters are edited in the middle, will investigate.