### PR TITLE
Nfultz/combined dataurls

### DIFF
--- a/odinochka.js
+++ b/odinochka.js
@@ -92,50 +92,51 @@ function cssfilter(x) {
         return;
     }
     let newfiltertxt = x.target.value;
-    let css = node.sheet;
-
-    var prefix = ""
-    for(var i = css.cssRules.length - 1; i >=0; i--) {
-        var rule = css.cssRules[i];
-        var pref = /:not\(\[href\*="(.*)"]\)/.exec(rule.selectorText)[1]
-        if(newfiltertxt.startsWith(pref)) {
-            prefix = pref;
-            break;
-        }
-        css.deleteRule(i); // have shortened query, delete
-    }
-
-    if(prefix == newfiltertxt) {
-        filtertxt = newfiltertxt;
-        return;
-    }
-
-    if(prefix == "") {
-        //keepselector = `a.tab[href*="${newfiltertxt}"]`;
-        selector  = `a.tab:not([href*="${newfiltertxt}"])`;
-        selector2 = `div.group:not([data-urls*="${newfiltertxt}"])`;
-    }
-    else {
-        keepselector = `a.tab[href*="${newfiltertxt}"]`;
-        selector  = `a.tab[href*="${prefix}"]:not([href*="${newfiltertxt}"])`;
-        selector2 = `div.group[data-urls*="${prefix}"]:not([data-urls*="${newfiltertxt}"])`;
-    }
-
-//    var hideGroups = new Set();
-//    document.querySelectorAll(".group").forEach(
-//        x => window.getComputedStyle(x).display == "block" &&
-//             ! x.querySelector(keepselector) ? hideGroups.add(x.id) : null)
-//
-//    for(var hide of hideGroups) {
-//        selector = selector + `, #\\3${hide.substring(0,1)} ${hide.substring(1,)}`
-//    }
-
-    css.insertRule(`${selector}, ${selector2} {display:none}`, css.cssRules.length);
+//     let css = node.sheet;
+// 
+//     var prefix = ""
+//     for(var i = css.cssRules.length - 1; i >=0; i--) {
+//         var rule = css.cssRules[i];
+//         var pref = /:not\(\[href\*="(.*)"]\)/.exec(rule.selectorText)[1]
+//         if(newfiltertxt.startsWith(pref)) {
+//             prefix = pref;
+//             break;
+//         }
+//         css.deleteRule(i); // have shortened query, delete
+//     }
+// 
+//     if(prefix == newfiltertxt) {
+//         filtertxt = newfiltertxt;
+//         return;
+//     }
+// 
+//     if(prefix == "") {
+//         //keepselector = `a.tab[href*="${newfiltertxt}"]`;
+         selector  = `a.tab:not([href*="${newfiltertxt}"])`;
+         selector2 = `div.group:not([data-urls*="${newfiltertxt}"])`;
+//     }
+//     else {
+//         keepselector = `a.tab[href*="${newfiltertxt}"]`;
+//         selector  = `a.tab[href*="${prefix}"]:not([href*="${newfiltertxt}"])`;
+//         selector2 = `div.group[data-urls*="${prefix}"]:not([data-urls*="${newfiltertxt}"])`;
+//     }
+// 
+// //    var hideGroups = new Set();
+// //    document.querySelectorAll(".group").forEach(
+// //        x => window.getComputedStyle(x).display == "block" &&
+// //             ! x.querySelector(keepselector) ? hideGroups.add(x.id) : null)
+// //
+// //    for(var hide of hideGroups) {
+// //        selector = selector + `, #\\3${hide.substring(0,1)} ${hide.substring(1,)}`
+// //    }
+// 
+//     css.insertRule(`${selector}, ${selector2} {display:none}`, css.cssRules.length);
+    node.innerHTML= `${selector}, ${selector2} {display:none}`
 
     //node.innerHTML = `a.tab:not([href*="${x.target.value}"]) {display:none} `;
     // TODO someday when :has works, also hide the empty groups
     //
-    filtertxt = newfiltertxt;
+//    filtertxt = newfiltertxt;
 }
 
 function doImport() {

--- a/odinochka.js
+++ b/odinochka.js
@@ -36,16 +36,12 @@ function attachUrlListSycher() {
                 //console.log({mut:mut})
                 let bf = mut.target.getAttribute("data-urls")
                 mut.removedNodes.forEach(x =>
-                    mut.target.setAttribute("data-urls",
-                        mut.target.getAttribute("data-urls").replace(RSEP + x.href + RSEP, RSEP)
-                    )
+                        bf = bf.replace(RSEP + x.href + RSEP, RSEP)
                 );
                 mut.addedNodes.forEach(x =>
-                    mut.target.setAttribute("data-urls",
-                        mut.target.getAttribute("data-urls") + RSEP + x.href + RSEP
-                    )
+                        bf += RSEP + x.href + RSEP
                 )
-                let af = mut.target.getAttribute("data-urls")
+                mut.target.setAttribute("data-urls", bf)
                 //console.log({bf:bf, mut:mut, af:af})
             }
         }
@@ -115,24 +111,26 @@ function cssfilter(x) {
     }
 
     if(prefix == "") {
-        keepselector = `a.tab[href*="${newfiltertxt}"]`;
-        selector = `a.tab:not([href*="${newfiltertxt}"])`;
+        //keepselector = `a.tab[href*="${newfiltertxt}"]`;
+        selector  = `a.tab:not([href*="${newfiltertxt}"])`;
+        selector2 = `div.group:not([data-urls*="${newfiltertxt}"])`;
     }
     else {
         keepselector = `a.tab[href*="${newfiltertxt}"]`;
-        selector = `a.tab[href*="${prefix}"]:not([href*="${newfiltertxt}"])`;
+        selector  = `a.tab[href*="${prefix}"]:not([href*="${newfiltertxt}"])`;
+        selector2 = `div.group[data-urls*="${prefix}"]:not([data-urls*="${newfiltertxt}"])`;
     }
 
-    var hideGroups = new Set();
-    document.querySelectorAll(".group").forEach(
-        x => window.getComputedStyle(x).display == "block" &&
-             ! x.querySelector(keepselector) ? hideGroups.add(x.id) : null)
+//    var hideGroups = new Set();
+//    document.querySelectorAll(".group").forEach(
+//        x => window.getComputedStyle(x).display == "block" &&
+//             ! x.querySelector(keepselector) ? hideGroups.add(x.id) : null)
+//
+//    for(var hide of hideGroups) {
+//        selector = selector + `, #\\3${hide.substring(0,1)} ${hide.substring(1,)}`
+//    }
 
-    for(var hide of hideGroups) {
-        selector = selector + `, #\\3${hide.substring(0,1)} ${hide.substring(1,)}`
-    }
-
-    css.insertRule(selector + "{display:none}", css.cssRules.length);
+    css.insertRule(`${selector}, ${selector2} {display:none}`, css.cssRules.length);
 
     //node.innerHTML = `a.tab:not([href*="${x.target.value}"]) {display:none} `;
     // TODO someday when :has works, also hide the empty groups

--- a/odinochka.js
+++ b/odinochka.js
@@ -1,7 +1,11 @@
 
+attachUrlListSycher()
 render()
 initOptions()
 closeOthers()
+
+
+
 
 function newWindow(data) {
   chrome.windows.create({url: data.urls}, function(w) {
@@ -13,6 +17,58 @@ function newWindow(data) {
 
 function newTabs(data) {
     data.tabs.forEach(o => chrome.tabs.create({url: o.url, pinned: o.pinned}))
+}
+
+
+function attachUrlListSycher() {
+    let groups = document.getElementById("groups");
+
+    let RSEP = "\036";
+
+    let observer = new MutationObserver((ml, obs) => {
+        let toUpdate = new Set();
+        for(let mut of ml) {
+            if(mut.target.id == "groups") {
+                mut.addedNodes.forEach(x => toUpdate.add(x));
+                mut.removedNodes.forEach(x => toUpdate.delete(x));
+            } else if (mut.target.className == "group") {
+
+                //console.log({mut:mut})
+                let bf = mut.target.getAttribute("data-urls")
+                mut.removedNodes.forEach(x =>
+                    mut.target.setAttribute("data-urls",
+                        mut.target.getAttribute("data-urls").replace(RSEP + x.href + RSEP, RSEP)
+                    )
+                );
+                mut.addedNodes.forEach(x =>
+                    mut.target.setAttribute("data-urls",
+                        mut.target.getAttribute("data-urls") + RSEP + x.href + RSEP
+                    )
+                )
+                let af = mut.target.getAttribute("data-urls")
+                //console.log({bf:bf, mut:mut, af:af})
+            }
+        }
+                //console.log(ml)
+
+
+        for(let grp of toUpdate) {
+            grp.setAttribute("data-urls",
+                RSEP + Array.from(grp.getElementsByTagName("A")).map(x=>x.href).join(RSEP) + RSEP
+            )
+        }
+
+
+
+    });
+
+
+
+    observer.observe(groups, {childList: true, subtree:true});
+
+
+
+
 }
 
 function debounce(func, wait, immediate) {

--- a/odinochka.js
+++ b/odinochka.js
@@ -64,13 +64,14 @@ function cssfilter(x) {
     }
     else {
         keepselector = `a.tab[href*="${newfiltertxt}"]`;
-        selector = `a.tab[href*=${prefix}]:not([href*="${newfiltertxt}"])`;
+        selector = `a.tab[href*="${prefix}"]:not([href*="${newfiltertxt}"])`;
     }
 
-    var hideGroups = new Set(Array.from(document.querySelectorAll(selector)).map(x => x.parentNode.id));
-    var keepGroups = new Set(Array.from(document.querySelectorAll(keepselector)).map(x => x.parentNode.id));
+    var hideGroups = new Set();
+    document.querySelectorAll(".group").forEach(
+        x => window.getComputedStyle(x).display == "block" &&
+             ! x.querySelector(keepselector) ? hideGroups.add(x.id) : null)
 
-    var hideGroups = Array.from(hideGroups).filter(x => !keepGroups.has(x));
     for(var hide of hideGroups) {
         selector = selector + `, #\\3${hide.substring(0,1)} ${hide.substring(1,)}`
     }

--- a/odinochka.js
+++ b/odinochka.js
@@ -83,60 +83,17 @@ function debounce(func, wait, immediate) {
     };
 }
 
-var filtertxt = "";
 function cssfilter(x) {
     let node = document.getElementById("cssfilterstyle");
-    if(x.target.value == "") {
-        node.innerHTML = "";
-        filtertxt = "";
-        return;
-    }
     let newfiltertxt = x.target.value;
-//     let css = node.sheet;
-// 
-//     var prefix = ""
-//     for(var i = css.cssRules.length - 1; i >=0; i--) {
-//         var rule = css.cssRules[i];
-//         var pref = /:not\(\[href\*="(.*)"]\)/.exec(rule.selectorText)[1]
-//         if(newfiltertxt.startsWith(pref)) {
-//             prefix = pref;
-//             break;
-//         }
-//         css.deleteRule(i); // have shortened query, delete
-//     }
-// 
-//     if(prefix == newfiltertxt) {
-//         filtertxt = newfiltertxt;
-//         return;
-//     }
-// 
-//     if(prefix == "") {
-//         //keepselector = `a.tab[href*="${newfiltertxt}"]`;
-         selector  = `a.tab:not([href*="${newfiltertxt}"])`;
-         selector2 = `div.group:not([data-urls*="${newfiltertxt}"])`;
-//     }
-//     else {
-//         keepselector = `a.tab[href*="${newfiltertxt}"]`;
-//         selector  = `a.tab[href*="${prefix}"]:not([href*="${newfiltertxt}"])`;
-//         selector2 = `div.group[data-urls*="${prefix}"]:not([data-urls*="${newfiltertxt}"])`;
-//     }
-// 
-// //    var hideGroups = new Set();
-// //    document.querySelectorAll(".group").forEach(
-// //        x => window.getComputedStyle(x).display == "block" &&
-// //             ! x.querySelector(keepselector) ? hideGroups.add(x.id) : null)
-// //
-// //    for(var hide of hideGroups) {
-// //        selector = selector + `, #\\3${hide.substring(0,1)} ${hide.substring(1,)}`
-// //    }
-// 
-//     css.insertRule(`${selector}, ${selector2} {display:none}`, css.cssRules.length);
-    node.innerHTML= `${selector}, ${selector2} {display:none}`
-
-    //node.innerHTML = `a.tab:not([href*="${x.target.value}"]) {display:none} `;
-    // TODO someday when :has works, also hide the empty groups
-    //
-//    filtertxt = newfiltertxt;
+    if(newfiltertxt == "") {
+        node.innerHTML = "";
+    }
+    else {
+        selector  = `a.tab:not([href*="${newfiltertxt}"])`;
+        selector2 = `div.group:not([data-urls*="${newfiltertxt}"])`;
+        node.innerHTML= `${selector}, ${selector2} {display:none}`
+    }
 }
 
 function doImport() {


### PR DESCRIPTION
Closes #1 #4 #5 

Instead of manually implementing `:has`, instead copy the urls onto the parent node, and filter on that copy.

the Mutation Observer can quickly synchronize the copy from changes to the DOM. This allows us to maintain the seperation between the database and ui.